### PR TITLE
Fix a bug where the Dataform project ID variable was not resolving co…

### DIFF
--- a/definitions/gold/demand_forecast.sqlx
+++ b/definitions/gold/demand_forecast.sqlx
@@ -22,7 +22,7 @@ config {
 WITH forecast_30_days AS (
   SELECT 30 AS forecast_horizon_days, *
   FROM ML.FORECAST(
-    MODEL `${dataform.projectConfig.defaultProject}.ml.demand_forecast_model`,
+    MODEL `careful-pilot-453607-k8.ml.demand_forecast_model`,
     STRUCT(30 AS horizon, 0.8 AS confidence_level)
   )
 ),
@@ -30,7 +30,7 @@ WITH forecast_30_days AS (
 forecast_90_days AS (
   SELECT 90 AS forecast_horizon_days, *
   FROM ML.FORECAST(
-    MODEL `${dataform.projectConfig.defaultProject}.ml.demand_forecast_model`,
+    MODEL `careful-pilot-453607-k8.ml.demand_forecast_model`,
     STRUCT(90 AS horizon, 0.8 AS confidence_level)
   )
 ),
@@ -38,7 +38,7 @@ forecast_90_days AS (
 forecast_180_days AS (
   SELECT 180 AS forecast_horizon_days, *
   FROM ML.FORECAST(
-    MODEL `${dataform.projectConfig.defaultProject}.ml.demand_forecast_model`,
+    MODEL `careful-pilot-453607-k8.ml.demand_forecast_model`,
     STRUCT(180 AS horizon, 0.8 AS confidence_level)
   )
 ),

--- a/definitions/ml/train_demand_forecast_model.sqlx
+++ b/definitions/ml/train_demand_forecast_model.sqlx
@@ -20,7 +20,7 @@ config {
   tags: ["ml", "training", "demand-planning"]
 }
 
-CREATE OR REPLACE MODEL `${dataform.projectConfig.defaultProject}.ml.demand_forecast_model`
+CREATE OR REPLACE MODEL `careful-pilot-453607-k8.ml.demand_forecast_model`
 OPTIONS(
   model_type = 'ARIMA_PLUS',
   time_series_timestamp_col = 'date',


### PR DESCRIPTION
…rrectly.

The `train_demand_forecast_model.sqlx` and `demand_forecast.sqlx` scripts were using the `${dataform.projectConfig.defaultProject}` variable to construct the model name. In the execution environment, this variable was resolving to `undefined`, causing the `CREATE MODEL` and `ML.FORECAST` calls to fail with a "Dataset not found" error.

This commit replaces the faulty variable with the hardcoded project ID (`careful-pilot-453607-k8`) in both files. This ensures that the model training and forecasting operations can correctly locate the `ml` dataset, resolving the bug.