### PR TITLE
This commit provides the definitive fix for the scalable forecasting …

### DIFF
--- a/definitions/gold/demand_forecast.sqlx
+++ b/definitions/gold/demand_forecast.sqlx
@@ -26,7 +26,12 @@ WITH future_features AS (
     d.year,
     d.month,
     d.day,
-    d.week
+    d.week,
+    -- The schema of this table MUST match the feature schema of the training data.
+    -- For features whose future values are unknown, we provide NULLs of the correct data type.
+    CAST(NULL AS FLOAT64) AS sales_lag_7d,
+    CAST(NULL AS FLOAT64) AS sales_mvg_avg_7d,
+    CAST(NULL AS FLOAT64) AS sales_mvg_avg_30d
   FROM UNNEST(GENERATE_DATE_ARRAY(
     -- Start forecasting from tomorrow
     DATE_ADD(CURRENT_DATE(), INTERVAL 1 DAY),


### PR DESCRIPTION
…pipeline, resolving a schema mismatch error when calling ML.FORECAST.

The `ARIMA_PLUS_XREG` model requires that the feature table passed to `ML.FORECAST` has the exact same schema as the data it was trained on. The previous implementation was only providing calendar features, causing a "Column not found" error for the other engineered features (e.g., `sales_lag_7d`).

This fix updates the `future_features` CTE in `demand_forecast.sqlx` to include all feature columns that were used during training. For features whose future values cannot be known (like lag or moving averages), `NULL` values of the correct data type are provided. This satisfies the model's schema requirement and allows the forecast to run successfully.

This commit should make the entire forecasting pipeline fully functional.