### PR TITLE
This commit provides the final fix for the scalable forecasting pipel…

### DIFF
--- a/definitions/gold/demand_forecast.sqlx
+++ b/definitions/gold/demand_forecast.sqlx
@@ -29,7 +29,7 @@ WITH future_features AS (
     d.week,
     -- The schema of this table MUST match the feature schema of the training data.
     -- For features whose future values are unknown, we provide NULLs of the correct data type.
-    CAST(NULL AS FLOAT64) AS sales_lag_7d,
+    CAST(NULL AS INT64) AS sales_lag_7d,
     CAST(NULL AS FLOAT64) AS sales_mvg_avg_7d,
     CAST(NULL AS FLOAT64) AS sales_mvg_avg_30d
   FROM UNNEST(GENERATE_DATE_ARRAY(


### PR DESCRIPTION
…ine, resolving a data type mismatch error in the `demand_forecast.sqlx` script.

The `ML.FORECAST` function for `ARIMA_PLUS_XREG` models requires the schema of the future features table to exactly match the schema of the training data. The `sales_lag_7d` column was being cast to `FLOAT64` in the future features table, while the model was trained on an `INT64` type for that column.

This commit changes the `CAST` for the `sales_lag_7d` column to `INT64`, aligning the schemas and resolving the type conversion error.

This should be the definitive fix that makes the entire forecasting pipeline fully functional.